### PR TITLE
Resolve federated learning rounds per epoch

### DIFF
--- a/fltk/core/federator.py
+++ b/fltk/core/federator.py
@@ -284,7 +284,7 @@ class Federator(Node):
             client_ref.exp_data.append(c_record)
 
         for client in selected_clients:
-            future = self.message_async(client.ref, Client.exec_round, num_epochs)
+            future = self.message_async(client.ref, Client.exec_round, num_epochs, com_round_id)
             cb_factory(future, training_cb, client, client_weights, client_sizes, num_epochs)
             self.logger.info(f'Request sent to client {client.name}')
             training_futures.append(future)

--- a/fltk/util/task/config/parameter.py
+++ b/fltk/util/task/config/parameter.py
@@ -5,6 +5,7 @@ from pathlib import Path
 # noinspection PyUnresolvedReferences
 from typing import List, Optional, OrderedDict, Any, Union, Tuple, Type, Dict, MutableMapping, T
 
+import deprecate
 from dataclasses_json import dataclass_json, LetterCase, config
 # noinspection PyProtectedMember
 from torch.nn.modules.loss import _Loss
@@ -224,7 +225,7 @@ class LearningParameters:
     Dataclass containing configuration parameters for the learning process itself. This includes the Federated learning
     parameters as well as some system parameters like cuda.
     """
-    total_epochs: int
+    _total_epochs: int = field(metadata=config(field_name='total_epochs'))
     cuda: bool
     rounds: Optional[int] = None
     epochs_per_round: Optional[int] = None
@@ -232,6 +233,11 @@ class LearningParameters:
     aggregation: Optional[Aggregations] = None
     data_sampler: Optional[SamplerConfiguration] = None
 
+    @property
+    def total_epochs(self):
+        logging.warning('By default `total_epochs` is not used duruing Federated Learning. This attribute will be'
+                        'changed in a comming release.')
+        return self.total_epochs
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass(frozen=True)
 class ExperimentConfiguration:

--- a/fltk/util/task/config/parameter.py
+++ b/fltk/util/task/config/parameter.py
@@ -225,7 +225,7 @@ class LearningParameters:
     Dataclass containing configuration parameters for the learning process itself. This includes the Federated learning
     parameters as well as some system parameters like cuda.
     """
-    _total_epochs: int = field(metadata=config(field_name='total_epochs'))
+    _total_epochs: int = field(metadata=config(field_name='totalEpochs'))
     cuda: bool
     rounds: Optional[int] = None
     epochs_per_round: Optional[int] = None
@@ -236,8 +236,10 @@ class LearningParameters:
     @property
     def total_epochs(self):
         logging.warning('By default `total_epochs` is not used duruing Federated Learning. This attribute will be'
-                        'changed in a comming release.')
-        return self.total_epochs
+                        'changed in a coming release.')
+        return self._total_epochs
+
+
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass(frozen=True)
 class ExperimentConfiguration:

--- a/tests/core/client_smoke_test.py
+++ b/tests/core/client_smoke_test.py
@@ -73,5 +73,5 @@ class TestFederatedLearnerSmoke(unittest.TestCase):
         self.assertTrue(fed_client.is_ready())
 
         with patch.object(DS, 'get_train_dataset', fed_client.dataset):
-            self.assertTrue(fed_client.exec_round(1))
+            self.assertTrue(fed_client.exec_round(1, 0))
 


### PR DESCRIPTION
## (Short) Description
This pull request addresses issue #40.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.



## (Optional) Additional remarks


 * This will break calls to `train` and `exec_round` in a client process, due to the introduction of `comm_round_id` to the federated clients.
<!-- Put additional remarks here, or leave empty -->
