### PR TITLE
Jupyter notebook cleanup + NFS provisioner Chart in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ python3 -m fltk extractor ./configs/example_cloud_experiment.json
 ```
 
 ## Deployment (Terraform)
-To setup the the test-bed using Terraform, the following setup needs to be done. This can be achieved through following
+To setup the test-bed using Terraform, the following setup needs to be done. This can be achieved through following
 the steps described in [`jupyter/terraform_notebook.ipynb`](jupyter/terraform_notebook.ipynb).
 
 ### Prerequisites
@@ -185,7 +185,7 @@ python3 -m venv venv-jupyter
 source venv-jupyter/bin/activate
 
 # Install python dependencies for running the notebook
-pip3 install jupyter ipython bash_kernel
+pip3 install -r requirements-jupyter.txt
 # Install bash kernel to use for the notebook
 python3 -m bash_kernel.install
 ```
@@ -198,8 +198,11 @@ When running the notebook (through an IDE or browser), make sure to set the kern
 To start working in the notebook, run the following command in a bash shell, and follow the steps in the notebook.
 
 ```bash
-cd jupyter
-jupyter notebook
+# To open browser automatically
+jupyter notebook jupyter/
+
+# To avoid opening in the browser and display the link instead
+jupyter notebook jupyter/ --no-browser
 ```
 
 Click on the link that is displayed in the output, default is `localhost:8888`, and open the terraform notebook.
@@ -213,9 +216,9 @@ The following commands will all (unless specified otherwise) be executed in the 
 Before we do so, first we need to setup a Python interpreter/environmen, this can also be used for development.
 
 
--   First we will create and active a Python venv.
+-   First we will create and activate a Python venv.
 
-    ``` bash
+    ```bash
     python3 -m venv venv
     source venv/bin/activate
     pip3 install -r requirements-cpu.txt
@@ -224,7 +227,7 @@ Before we do so, first we need to setup a Python interpreter/environmen, this ca
 -   Then we will download the datasets using a Python script in the same
     terminal (or another terminal with the `venv` activated).
 
-    ``` bash
+    ```bash
     python3 -m fltk extractor ./configs/example_cloud_experiment.json
     ```
 
@@ -232,7 +235,7 @@ Afterwards, we can run the following commands to build the Docker
 container. With the use of BuildKit, consecutive builds allow to use cached requirements. Speeding
 up your builds when adding Python dependencies to your project.
 
-``` bash
+```bash
 DOCKER_BUILDKIT=1 docker build --platform linux/amd64 . --tag gcr.io/<project-id>/fltk
 docker push gcr.io/<project-id>/fltk
 ```
@@ -254,7 +257,7 @@ Helm chart, under the name `extractor` in the `test` Namespace.\
 Make sure to update the project name in the `chart` of the extractor in case you have changed
 the default `PROJECT_ID`.
 
-``` bash
+```bash
 cd charts
 helm install extractor ./extractor -f fltk-values.yaml --namespace test
 ```
@@ -268,8 +271,9 @@ Note that downloading many small files is slow (as they will be
 compressed individually). The command assumes that the default name is
 used `fl-extractor`.
 
-``` bash
-kubectl cp --namespace test fl-extractor:/opt/federation-lab/logging ./logging
+```bash
+EXTRACTOR_POD_NAME=$(kubectl get pods -n test -l "app.kubernetes.io/name=fltk.extractor" -o jsonpath="{.items[0].metadata.name}")
+kubectl cp -n test $EXTRACTOR_POD_NAME:/opt/federation-lab/logging ./logging
 ```
 
 Which will copy the data to a directory logging (you may have to create
@@ -284,7 +288,7 @@ running actual experiments.
 ##### Federated Experiment
 
 ```bash
-helm install flearner charts/orchestrator --namespace test -f charts/fltk-values.yaml\
+helm install flearner charts/orchestrator --namespace test -f charts/fltk-values.yaml \
   --set-file orchestrator.experiment=./configs/federated_tasks/example_arrival_config.json,\
   orchestrator.configuration=./configs/example_cloud_experiment.json
 ```
@@ -292,7 +296,7 @@ helm install flearner charts/orchestrator --namespace test -f charts/fltk-values
 ##### Distributed Experiment
 
 ```bash
-helm install flearner charts/orchestrator --namespace test -f charts/fltk-values.yaml\
+helm install flearner charts/orchestrator --namespace test -f charts/fltk-values.yaml \
   --set-file orchestrator.experiment=./configs/distributed_tasks/example_arrival_config.json,\
   orchestrator.configuration=./configs/example_cloud_experiment.json
 ```

--- a/jupyter/experiment_notebook.ipynb
+++ b/jupyter/experiment_notebook.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "# These commands might take a while to complete.\n",
     "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
-    "     --num-nodes 1 --region us-central1-c --quiet"
+    "     --num-nodes 1 --region $REGION --quiet"
    ]
   },
   {
@@ -132,7 +132,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "helm install -n test extractor ../charts/extractor -f ../charts/fltk-values.yaml"
+    "helm upgrade --install -n test extractor ../charts/extractor -f ../charts/fltk-values.yaml \\\n",
+    "    --set provider.projectName=$PROJECT_ID"
    ]
   },
   {
@@ -200,9 +201,10 @@
    },
    "outputs": [],
    "source": [
-    "helm uninstall experiment-orchestrator -n test\n",
-    "helm install experiment-orchestrator ../charts/orchestrator --namespace test -f ../charts/fltk-values.yaml \\\n",
-    "  --set-file orchestrator.experiment=$EXPERIMENT_FILE,orchestrator.configuration=$CLUSTER_CONFIG\n"
+    "helm uninstall -n test experiment-orchestrator\n",
+    "helm install -n test experiment-orchestrator ../charts/orchestrator -f ../charts/fltk-values.yaml \\\n",
+    "    --set-file orchestrator.experiment=$EXPERIMENT_FILE,orchestrator.configuration=$CLUSTER_CONFIG \\\n",
+    "    --set provider.projectName=$PROJECT_ID"
    ]
   },
   {
@@ -216,7 +218,7 @@
    "outputs": [],
    "source": [
     "# To get logs from the orchestrator\n",
-    "kubectl logs -n test fl-learner"
+    "kubectl logs -n test fl-server"
    ]
   },
   {
@@ -238,13 +240,75 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Copy experiment results from the extractor\n",
+    "\n",
+    "Extractor holds the experiment results in the format that can be processedby TensorBoard.\n",
+    "In order to download it to the local machine, execute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXTRACTOR_POD_NAME=$(kubectl get pods -n test -l \"app.kubernetes.io/name=fltk.extractor\" -o jsonpath=\"{.items[0].metadata.name}\")\n",
+    "\n",
+    "kubectl cp -n test $EXTRACTOR_POD_NAME:/opt/federation-lab/logging ./logging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cleanup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Removing orchestrator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "helm uninstall -n test experiment-orchestrator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Removing extractor\n",
+    "\n",
+    "IMPORTANT: Removing extractor chart will result in deleting the already collected experiment results, stored in the NFS!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "helm uninstall extractor -n test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%% md\n"
     }
    },
    "source": [
-    "# Wrapping up\n",
+    "## Wrapping up\n",
     "\n",
     "To scale down the cluster nodepools, run the cell below. This will scale the node pools down and remove all the experiments deployed (on the cluster).\n",
     "\n",
@@ -266,7 +330,7 @@
     "kubectl delete pytorchjobs.kubeflow.org --all-namespaces --all\n",
     "\n",
     "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
-    "     --num-nodes 0 --region $REGION --quiet\n",
+    "    --num-nodes 0 --region $REGION --quiet\n",
     "\n",
     "gcloud container clusters resize $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
     "    --num-nodes 0 --region $REGION --quiet"

--- a/jupyter/experiment_notebook.ipynb
+++ b/jupyter/experiment_notebook.ipynb
@@ -17,11 +17,11 @@
     "* GKE/Kubernetes cluster (see also `terraform/terraform_notebook.ipynb`)\n",
     "    * 2 nodes pools (default for system & dependencies, experiment pool)\n",
     "* Docker image (including dataset, to speed-up starting experiments).\n",
-    "    * Within a BASH shell\n",
+    "    * Within a bash shell\n",
     "        * Make sure to have the `requirements-cpu.txt` installed (or `requirements-gpu.txt (in a virtual venv/conda environment). You can run `pip3 install -r requirements-cpu.txt`\n",
-    "    * First run the extractor (locally) `python3 -m extractor configs/example_cloud_experiment.json`\n",
+    "    * First run the extractor (locally) `python3 -m fltk extractor configs/example_cloud_experiment.json`\n",
     "        *  This downloads datasets to be included in the docker image.\n",
-    "    * Build the container `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 . --tag gcr.io/\\$PROJECT_ID/fltk`\n",
+    "    * Build the container `DOCKER_BUILDKIT=1 docker build --platform linux/amd64 . --tag gcr.io/$PROJECT_ID/fltk`\n",
     "    * Push to your gcr.io repository `docker push gcr.io/$PROJECT_ID/fltk`\n",
     "\n",
     "\n",
@@ -38,6 +38,9 @@
    },
    "outputs": [],
    "source": [
+    "##################\n",
+    "### CHANGE ME! ###\n",
+    "##################\n",
     "PROJECT_ID=\"test-bed-fltk\"\n",
     "CLUSTER_NAME=\"fltk-testbed-cluster\"\n",
     "DEFAULT_POOL=\"default-node-pool\"\n",
@@ -71,10 +74,7 @@
    "source": [
     "# These commands might take a while to complete.\n",
     "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
-    "     --num-nodes 2 --region us-central1-c --quiet\n",
-    "\n",
-    "gcloud container clusters resize $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
-    "    --num-nodes 3 --region us-central1-c --quiet"
+    "     --num-nodes 1 --region us-central1-c --quiet"
    ]
   },
   {
@@ -109,12 +109,30 @@
    "outputs": [],
    "source": [
     "# If you want to delete all pytorch trainjobs, uncomment the command below.\n",
-    "#  kubectl delete pytorchjobs.kubeflow.org --all --namespace test\n",
+    "# kubectl delete pytorchjobs.kubeflow.org --all --namespace test\n",
     "\n",
     "# If you want to delete all existing configuration map objects in a namespace, run teh command below\n",
     "# kubectl delete configmaps --all --namespace test\n",
     "\n",
     "helm uninstall -n test flearner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install extractor\n",
+    "\n",
+    "Deploy the TensorBoard service and persistent volumes, required for deployment of the orchestrator's chart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "helm install -n test extractor ../charts/extractor -f ../charts/fltk-values.yaml"
    ]
   },
   {
@@ -144,25 +162,9 @@
    },
    "outputs": [],
    "source": [
-    "# Change the directory to a level above, i.e. content root (the git root directory).\n",
-    "cd ../\n",
-    "echo $PWD"
+    "EXPERIMENT_FILE=\"../configs/federated_tasks/example_arrival_config.json\"\n",
+    "CLUSTER_CONFIG=\"../configs/example_cloud_experiment.json\""
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "EXPERIMENT_FILE=\"configs/federated_tasks/example_arrival_config.json\"\n",
-    "CLUSTER_CONFIG=\"configs/example_arrival_config\""
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
   },
   {
    "cell_type": "markdown",
@@ -199,7 +201,7 @@
    "outputs": [],
    "source": [
     "helm uninstall experiment-orchestrator -n test\n",
-    "helm install experiment-orchestrator charts/orchestrator --namespace test -f charts/fltk-values.yaml\\\n",
+    "helm install experiment-orchestrator ../charts/orchestrator --namespace test -f ../charts/fltk-values.yaml \\\n",
     "  --set-file orchestrator.experiment=$EXPERIMENT_FILE,orchestrator.configuration=$CLUSTER_CONFIG\n"
    ]
   },
@@ -236,6 +238,11 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Wrapping up\n",
     "\n",
@@ -243,34 +250,27 @@
     "\n",
     "1. Experiments cannot be restarted.\n",
     "2. Experiment logs will not persist deletion.\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# This will remove all information and logs as well.\n",
     "kubectl delete pytorchjobs.kubeflow.org --all-namespaces --all\n",
     "\n",
     "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
-    "     --num-nodes 0 --region us-central1-c --quiet\n",
+    "     --num-nodes 0 --region $REGION --quiet\n",
     "\n",
     "gcloud container clusters resize $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
-    "    --num-nodes 0 --region us-central1-c --quiet"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+    "    --num-nodes 0 --region $REGION --quiet"
+   ]
   }
  ],
  "metadata": {

--- a/jupyter/terraform_notebook.ipynb
+++ b/jupyter/terraform_notebook.ipynb
@@ -650,10 +650,43 @@
     }
    },
    "source": [
-    "# Cleaning up\n",
+    "# Cleaning up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scaling down the cluster\n",
+    "\n",
+    "This is the preferred way to scale down.\n",
+    "Scale node pools down to prevent idle resource utilization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
+    "     --num-nodes 0 --region $REGION --quiet\n",
+    "\n",
+    "gcloud container clusters resize $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
+    "    --num-nodes 0 --region $REGION --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Destroying the cluster\n",
     "\n",
     "> ⚠️ THIS WILL REMOVE YOUR CLUSTER AND DATA STORED ON IT. For this tutorial's purpose destroying your cluster is not an issue. For testing/developing, we recommend manually scaling your cluster up and down instead.\n",
-    "\n",
     "\n",
     "To clean up/remove the cluster, we will use the `terraform destroy` command.\n",
     "\n",
@@ -668,36 +701,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# THIS WILL REMOVE/TEARDOWN YOUR CLUSTER, ONLY RECOMMENDED FOR TESTING THE DEPLOYMENT\n",
-    "# terraform -chdir=$TERRAFORM_DEPENDENCIES_DIR destroy -auto-approve"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Scale node pools down to prevent idle resource utilization.\n",
     "\n",
-    "# THIS IS THE PREFERRED WAY TO SCALE DOWN\n",
+    "terraform -chdir=$TERRAFORM_DEPENDENCIES_DIR destroy -auto-approve -var project_id=$PROJECT_ID\n",
     "\n",
-    "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
-    "     --num-nodes 0 --region $REGION --quiet\n",
-    "\n",
-    "gcloud container clusters resize $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
-    "    --num-nodes 0 --region $REGION --quiet\n"
+    "terraform -chdir=$TERRAFORM_GKE_DIR destroy -auto-approve -var project_id=$PROJECT_ID"
    ]
   }
  ],

--- a/jupyter/terraform_notebook.ipynb
+++ b/jupyter/terraform_notebook.ipynb
@@ -203,7 +203,7 @@
     "##################\n",
     "### CHANGE ME! ###\n",
     "##################\n",
-    "BILLING_ACCOUNT=\"015594-41687F-092941\"      "
+    "BILLING_ACCOUNT=\"015594-41687F-092941\""
    ]
   },
   {
@@ -310,7 +310,7 @@
     "##################\n",
     "### CHANGE ME! ###\n",
     "##################\n",
-    "OWNER_MAIL=\"jargsnork@gmail.com\"\n",
+    "OWNER_MAIL=\"mygoogleaccount@gmail.com\"\n",
     "\n",
     "gcloud iam service-accounts add-iam-policy-binding $PRIVILEGED_ACCOUNT_ID \\\n",
     " --member=\"user:$OWNER_MAIL\" \\\n",
@@ -480,11 +480,11 @@
    "outputs": [],
    "source": [
     "gcloud container clusters update $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
-    "    --disable-autoscaling --quiet\n",
+    "    --no-enable-autoscaling --region $REGION --quiet\n",
     "    \n",
     "# The high performance node will scale up automatically whenever the workloads are deployed\n",
     "gcloud container clusters update $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
-    "    --enable-autoscaling --quiet\n",
+    "    --enable-autoscaling --min-nodes=0 --max-nodes=10 --region $REGION --quiet\n",
     "\n",
     "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
     "    --num-nodes 1 --region $REGION --quiet\n"
@@ -636,7 +636,7 @@
    "outputs": [],
    "source": [
     "# Retrieve all CRD Pytorchjob from Kubeflow.\n",
-    "kubectl get pytorchjobs.kubeflow.org --all-namespaces --all\n",
+    "kubectl get pytorchjobs.kubeflow.org --all-namespaces\n",
     "\n",
     "# Alternatively, we can remove all jobs, this will remove all information and logs as well.\n",
     "kubectl delete pytorchjobs.kubeflow.org --all-namespaces --all"

--- a/jupyter/terraform_notebook.ipynb
+++ b/jupyter/terraform_notebook.ipynb
@@ -23,11 +23,15 @@
     "2. Start the Ubuntu Bash shell by searching for `Bash` under Start, or by running `bash` in a (normal) PowerShell terminal.\n",
     "\n",
     "Using a Bash terminal as started under step 2 above, you can install the Requirements as described below as if you are running it under Linux or Ubuntu/Debian."
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Requirements\n",
     "These requirements may also be installed on Windows, however, development has only been tested on Linux/macOS.\n",
@@ -57,7 +61,7 @@
     " * Python3.9/10\n",
     "   * jupyter, ipython, bash_kernel\n",
     "```bash\n",
-    "pip3 install jupyter ipython bash_kernel\n",
+    "pip3 install -r requirements-jupyter.txt\n",
     "python3 -m bash_kernel.install\n",
     "```\n",
     "\n",
@@ -69,14 +73,7 @@
     " * Python3.9\n",
     " * pip3\n",
     " * JetBrains PyCharm"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -135,13 +132,22 @@
    "outputs": [],
    "source": [
     "# VARIABLES THAT NEEDS TO BE SET\n",
-    "PROJECT_ID=\"test-bed-fltk\"              # CHANGE ME!\n",
+    "\n",
+    "##################\n",
+    "### CHANGE ME! ###\n",
+    "##################\n",
+    "PROJECT_ID=\"test-bed-fltk\"\n",
     "\n",
     "# DEFAULT VARIABLES\n",
     "ACCOUNT_ID=\"terraform-iam-service-account\"\n",
     "PRIVILEGED_ACCOUNT_ID=\"${ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com\"\n",
     "CLUSTER_NAME=\"fltk-testbed-cluster\"\n",
-    "REGION=\"us-central1-c\""
+    "DEFAULT_POOL=\"default-node-pool\"\n",
+    "EXPERIMENT_POOL=\"medium-fltk-pool-1\"\n",
+    "REGION=\"us-central1-c\"\n",
+    "\n",
+    "TERRAFORM_GKE_DIR=\"../terraform/terraform-gke\"\n",
+    "TERRAFORM_DEPENDENCIES_DIR=\"../terraform/terraform-dependencies\""
    ]
   },
   {
@@ -194,7 +200,10 @@
    },
    "outputs": [],
    "source": [
-    "BILLING_ACCOUNT=\"015594-41687F-092941\"      # CHANGE ME!"
+    "##################\n",
+    "### CHANGE ME! ###\n",
+    "##################\n",
+    "BILLING_ACCOUNT=\"015594-41687F-092941\"      "
    ]
   },
   {
@@ -298,7 +307,11 @@
    },
    "outputs": [],
    "source": [
+    "##################\n",
+    "### CHANGE ME! ###\n",
+    "##################\n",
     "OWNER_MAIL=\"jargsnork@gmail.com\"\n",
+    "\n",
     "gcloud iam service-accounts add-iam-policy-binding $PRIVILEGED_ACCOUNT_ID \\\n",
     " --member=\"user:$OWNER_MAIL\" \\\n",
     " --role=roles/iam.serviceAccountTokenCreator \\\n",
@@ -342,81 +355,59 @@
     "## Creating a Google managed cluster (GKE)\n",
     "To create the cluster, first change the active directory to the `terraform-gke` directory.\n",
     "\n",
-    "⚠️ Creating a cluster will incur billing cost on your project, by default the cluster will be small to minimize costs during this tutorial. Forgetting to `destroy` or scale down the cluster may result in quickly spending your academic coupon."
+    "⚠️ Creating a cluster will incur billing cost on your project, by default the cluster will be small to minimize costs during this tutorial. Forgetting to `destroy` or scale down the cluster may result in quickly spending your academic coupon.\n",
+    "\n",
+    "Init the directory, to initialize the Terraform module."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "cd ../terraform/terraform-gke"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "terraform -chdir=$TERRAFORM_GKE_DIR init "
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Init the directory, to initialize the Terraform module."
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "terraform init "
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "markdown",
+   },
    "source": [
     "Next, we can check whether we can create a cluster. No warnings or errors should occur during this process. It may take a while to complete.\n",
     "\n",
     "> ⚠️ We provide the project_id variable from `terraform/terraform-gke` manually, and also change the default value.\n",
     "\n",
     "⁉️ If the command below does not complete successfully, e.g. after raising a `403` error, make sure that you have successfully created the project with `gcloud` earlier.\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "terraform plan -var project_id=$PROJECT_ID"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "terraform -chdir=$TERRAFORM_GKE_DIR plan -var project_id=$PROJECT_ID"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "When the previous command completes successfully, we can start the deployment. Depending on any changes you may have done, this might take a while.\n",
     "\n",
@@ -425,90 +416,87 @@
     "> ⚠️ A regional cluster (multi-zonal) will incur an additional fee of \\\\$ 0.10 /hour per managed (GKE) cluster. The **first** zonal cluster is free of this charge.\n",
     "\n",
     "> ⚠️ By default spot/preemptive nodes are disabled. You can experiment by setting `spot` to true in the `tf` files. Note, however, that the default implementations provided in the testbed do not allow for recovery from getting spun down and rescheduled. Moreover, this may result in poor availability during busy hours in the region in which you deploy your cluster.\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "terraform apply -auto-approve -var project_id=$PROJECT_ID"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "Next, we add cluster credentials (so you can interact with the cluster through `kubectl` an `helm`)."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
-    "# Add credentials for interacting with cluster via kubectl\n",
-    "gcloud container clusters get-credentials $CLUSTER_NAME --region $REGION --project $PROJECT_ID"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+    "terraform -chdir=$TERRAFORM_GKE_DIR apply -auto-approve -var project_id=$PROJECT_ID"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "⚠️ The cluster by default does not contain any nodes in the node pools, the `initial_node_count` is set to 0.\n",
-    "\n",
-    "Lastly, we need to scale up the cluster, as by default we create a cluster with nodepools of size 0."
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
    },
-   "outputs": []
+   "source": [
+    "Next, we add cluster credentials (so you can interact with the cluster through `kubectl` an `helm`)."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "gcloud container clusters resize $CLUSTER_NAME --node-pool \"default-node-pool\" \\\n",
-    "     --num-nodes 2 --region us-central1-c --quiet\n",
-    "\n",
-    "gcloud container clusters resize $CLUSTER_NAME --node-pool \"medium-fltk-pool-1\" \\\n",
-    "    --num-nodes 2 --region us-central1-c --quiet\n"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# Add credentials for interacting with cluster via kubectl\n",
+    "gcloud container clusters get-credentials $CLUSTER_NAME --region $REGION --project $PROJECT_ID"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "⚠️ The cluster by default does not contain any nodes in the node pools, the `initial_node_count` is set to 0.\n",
+    "\n",
+    "Lastly, we need to scale up the cluster, as by default we create a cluster with nodepools of size 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "gcloud container clusters update $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
+    "    --disable-autoscaling --quiet\n",
+    "    \n",
+    "# The high performance node will scale up automatically whenever the workloads are deployed\n",
+    "gcloud container clusters update $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
+    "    --enable-autoscaling --quiet\n",
+    "\n",
+    "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
+    "    --num-nodes 1 --region $REGION --quiet\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Changing deployment\n",
     "\n",
@@ -526,131 +514,85 @@
     "```\n",
     "\n",
     "Depending on the number of changes, this may take some time."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Installing dependencies\n",
-    "Lastly, we need to install the dependencies on our cluster. First change the directories, and then run the `init`, `plan` and `apply` commands as we did for creating the GKE cluster."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "cd ../terraform/terraform-dependencies"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
+    "Lastly, we need to install the dependencies on our cluster. First change the directories, and then run the `init`, `plan` and `apply` commands as we did for creating the GKE cluster.\n",
+    "\n",
     "Init the directory, to initialize the Terraform module."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "terraform init -reconfigure"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "terraform -chdir=$TERRAFORM_DEPENDENCIES_DIR init -reconfigure"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Check to see if we can plan the deployment. This will setup the following:\n",
     "\n",
     "* Kubeflow training operator (used to deploy and manage PyTorchTrainJobs programmatically)\n",
     "* NFS-provisioner (used to enable logging on a persistent `ReadWriteMany` PVC in the cluster)\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "terraform plan -var project_id=$PROJECT_ID"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "terraform -chdir=$TERRAFORM_DEPENDENCIES_DIR plan -var project_id=$PROJECT_ID"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "When the previous command completes successfully, we can start the deployment. This will install the NFS provisioner and Kubeflow Training Operator dependencies\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "terraform apply -auto-approve -var project_id=$PROJECT_ID"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "terraform -chdir=$TERRAFORM_DEPENDENCIES_DIR apply -auto-approve -var project_id=$PROJECT_ID"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -686,6 +628,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Retrieve all CRD Pytorchjob from Kubeflow.\n",
@@ -693,13 +640,7 @@
     "\n",
     "# Alternatively, we can remove all jobs, this will remove all information and logs as well.\n",
     "kubectl delete pytorchjobs.kubeflow.org --all-namespaces --all"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -719,7 +660,7 @@
     " * Running it in `terraform-dependencies` WILL REMOVE the Kubeflow Training-Operator from your cluster.\n",
     " * Running it in `terraform-gke` WILL REMOVE YOU ENTIRE CLUSTER.\n",
     "\n",
-    "You can uncomment the commands below to remove the cluster, or run the command in a terminal in the [`.../terraform/terraform-gke`](../terraform/terraform-gke) directory.\n",
+    "You can uncomment the commands below to remove the cluster, or run the command in a terminal in the [`../terraform/terraform-gke`](../terraform/terraform-gke) directory.\n",
     "\n",
     "> ⚠️ It is recommended to scale down the cluster/nodepools rather then destroying, refer to the last code block."
    ]
@@ -734,37 +675,33 @@
    },
    "outputs": [],
    "source": [
-    "cd ../terraform-gke\n",
-    "\n",
     "# THIS WILL REMOVE/TEARDOWN YOUR CLUSTER, ONLY RECOMMENDED FOR TESTING THE DEPLOYMENT\n",
-    "# terraform destroy -auto-approve"
+    "# terraform -chdir=$TERRAFORM_DEPENDENCIES_DIR destroy -auto-approve"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Scale node pools down to prevent idle resource utilization.\n",
     "\n",
     "# THIS IS THE PREFERRED WAY TO SCALE DOWN\n",
     "\n",
-    "gcloud container clusters resize $CLUSTER_NAME --node-pool \"default-node-pool\" \\\n",
-    "     --num-nodes 0 --region us-central1-c --quiet\n",
+    "gcloud container clusters resize $CLUSTER_NAME --node-pool $DEFAULT_POOL \\\n",
+    "     --num-nodes 0 --region $REGION --quiet\n",
     "\n",
-    "gcloud container clusters resize $CLUSTER_NAME --node-pool \"medium-fltk-pool-1\" \\\n",
-    "    --num-nodes 0 --region us-central1-c --quiet\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+    "gcloud container clusters resize $CLUSTER_NAME --node-pool $EXPERIMENT_POOL \\\n",
+    "    --num-nodes 0 --region $REGION --quiet\n"
+   ]
   }
  ],
  "metadata": {
-  "title": "Tutorial (Terraform)",
   "kernelspec": {
    "display_name": "Bash",
    "language": "bash",
@@ -775,7 +712,8 @@
    "file_extension": ".sh",
    "mimetype": "text/x-sh",
    "name": "bash"
-  }
+  },
+  "title": "Tutorial (Terraform)"
  },
  "nbformat": 4,
  "nbformat_minor": 1

--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -1,0 +1,3 @@
+bash_kernel==0.8.0
+ipython==8.5.0
+jupyter==1.0.0

--- a/terraform/terraform-dependencies/main.tf
+++ b/terraform/terraform-dependencies/main.tf
@@ -15,8 +15,7 @@ resource "kustomization_resource" "training_operator" {
 # Create NFS resource
 resource "helm_release" "nfs_client_provisioner" {
   name       = var.nfs_provider_information.release_name
-  repository = var.nfs_provisioner_repo_url
-  chart      = var.nfs_provider_information.chart_name
+  chart      = "charts/nfs-server-provisioner-1.1.3.tgz"
 
   namespace        = var.nfs_provider_information.namespace
   create_namespace = true

--- a/terraform/terraform-dependencies/variables.tf
+++ b/terraform/terraform-dependencies/variables.tf
@@ -67,8 +67,3 @@ variable "nfs_provider_information" {
   }
 }
 
-variable "nfs_provisioner_repo_url" {
-  description = "Repository URL to locate the utilized helm charts"
-  type        = string
-  default     = "https://charts.helm.sh/stable"
-}


### PR DESCRIPTION
Streamlined the way of working with the project from within the Jupyter notebook:
1. Added separate `requirements-jupyter.txt` file for Jupyter's virtual environment - faster and more maintainable than copy pasting the `pip install` with the required packages
2. Cleaned up Terraform notebook
     1. Added clear comments on the fields that should be changed (e.g. project name, owner's email)
     2. Removed the `cd` commands. Changing working directory in the scripts is generally discouraged (should be done with subshells instead), and is particularly cumbersome in the Jupyter notebook, where cells can be executed out of order. Terraform supports specifying working directory with the `-chdir` parameter.
     3. Added scaling configuration for the node pools. The Terraform module, which deploys GKE, seems to be buggy as the deployed infrastructure state is not the same as defined in the HCL files. For example, autoscaling is enabled for both node pools, even though it's disabled in the HCL. This leads to situation, where the PyTorch jobs are executed on the default pool nodes and scale it up, instead of using the high performance FLTK node pool. The current configuration in the notebook disables scaling of the default node pool and sets its size to 1, while the FLTK pool has autoscaling enabled, with 0-10 nodes. The nodes will be created whenever the new PyTorch job Pods are created.
3. Cleaned up experiment notebook
     1. As before, added visible comments on the fields that should be changed
     2. Added missing `fltk` entry in `python3 -m fltk extractor configs/example_cloud_experiment.json`
     3. Added extractor Helm Chart installation
     4. Fixed environment variable values with the paths to experiment file and cluster config
     5. Providing Helm with the project ID during Chart installations, so that it's not necessary to modify the `fltk-values.yaml` file anymore - one less thing to remember
     6. Added cell for copying experiment results from the extractor to the local machine
     7. Added cleanup cells, for removing orchestrator and extractor

Additionally, I've modified the Terraform resource, responsible for creation of a NFS file provisioner - the Chart's archive is now locally stored in the repository, which will help to avoid the situation, where Helm provider behaves weird when trying to pull the chart and returns non-meaningful errors (increasing verbosity with `export TF_LOG=debug` didn't provide any information like the HTTP error code):
![Screenshot from 2022-09-22 22-39-38](https://user-images.githubusercontent.com/4958634/191862258-ad556855-8136-4f22-83b9-cba3d794210d.png)

