### PR TITLE
Hotfix NFS provisioner

### DIFF
--- a/terraform/terraform-dependencies/main.tf
+++ b/terraform/terraform-dependencies/main.tf
@@ -15,7 +15,8 @@ resource "kustomization_resource" "training_operator" {
 # Create NFS resource
 resource "helm_release" "nfs_client_provisioner" {
   name       = var.nfs_provider_information.release_name
-  chart      = "charts/nfs-server-provisioner-1.1.3.tgz"
+  repository = var.nfs_provisioner_repo_url
+  chart      = var.nfs_provider_information.chart_name
 
   namespace        = var.nfs_provider_information.namespace
   create_namespace = true

--- a/terraform/terraform-dependencies/variables.tf
+++ b/terraform/terraform-dependencies/variables.tf
@@ -67,3 +67,8 @@ variable "nfs_provider_information" {
   }
 }
 
+variable "nfs_provisioner_repo_url" {
+  description = "Repository URL to locate the utilized helm charts"
+  type        = string
+  default     = "https://charts.helm.sh/stable"
+}


### PR DESCRIPTION
This hotfix resolves the issue that the NFS provisioned chart needs to be available locally. This is **not** the case when the chart has not been used previously
